### PR TITLE
Add editing and calendar views

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -33,3 +33,7 @@ button {
   padding: 6px 12px;
   cursor: pointer;
 }
+
+.other-month {
+  background-color: #f0f0f0;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,6 +8,7 @@
 <body>
   <nav>
     <a href="{{ url_for('index') }}">履歴</a> |
+    <a href="{{ url_for('calendar_view') }}">カレンダー</a> |
     <a href="{{ url_for('exercises') }}">エクササイズ管理</a> |
     <a href="{{ url_for('log') }}">ログ記録</a>
   </nav>

--- a/templates/calendar.html
+++ b/templates/calendar.html
@@ -1,0 +1,28 @@
+{% extends 'base.html' %}
+{% block title %}カレンダー{% endblock %}
+{% block content %}
+<h1>{{ year }}年{{ month }}月</h1>
+<table>
+  <tr>
+    <th>月</th>
+    <th>火</th>
+    <th>水</th>
+    <th>木</th>
+    <th>金</th>
+    <th>土</th>
+    <th>日</th>
+  </tr>
+  {% for week in days %}
+  <tr>
+    {% for day in week %}
+    <td {% if day.month != month %}class="other-month"{% endif %}>
+      {{ day.day }}
+      {% for name in events.get(day.strftime('%Y-%m-%d'), []) %}
+      <div>{{ name }}</div>
+      {% endfor %}
+    </td>
+    {% endfor %}
+  </tr>
+  {% endfor %}
+</table>
+{% endblock %}

--- a/templates/edit_workout.html
+++ b/templates/edit_workout.html
@@ -1,0 +1,36 @@
+{% extends 'base.html' %}
+{% block title %}ログ編集{% endblock %}
+{% block content %}
+<h1>ログを編集</h1>
+<form method="post">
+  <table>
+    <tr>
+      <td>日付：</td>
+      <td><input type="date" name="date" value="{{ workout.date }}"></td>
+    </tr>
+    <tr>
+      <td>種目：</td>
+      <td>
+        <select name="exercise_id">
+          {% for e in exercises %}
+            <option value="{{ e.id }}" {% if e.id == workout.exercise_id %}selected{% endif %}>{{ e.name }}（{{ e.muscle_group }}）</option>
+          {% endfor %}
+        </select>
+      </td>
+    </tr>
+    <tr>
+      <td>セット数：</td>
+      <td><input type="number" name="sets" value="{{ workout.sets }}" required></td>
+    </tr>
+    <tr>
+      <td>回数：</td>
+      <td><input type="number" name="reps" value="{{ workout.reps }}" required></td>
+    </tr>
+    <tr>
+      <td>重量(kg)：</td>
+      <td><input type="number" name="weight" step="2" value="{{ workout.weight }}" required></td>
+    </tr>
+  </table>
+  <button type="submit">更新</button>
+</form>
+{% endblock %}

--- a/templates/exercises.html
+++ b/templates/exercises.html
@@ -3,18 +3,27 @@
 {% block content %}
 <h1>エクササイズ管理</h1>
 
-<ul>
+<table>
+  <tr>
+    <th>番号</th>
+    <th>名前</th>
+    <th>部位</th>
+    <th>操作</th>
+  </tr>
   {% for e in exercises %}
-    <li>
-      {{ e.id }}：{{ e.name }}（{{ e.muscle_group }}）
-      <!-- 削除ボタン -->
+  <tr>
+    <td>{{ loop.index }}</td>
+    <td>{{ e.name }}</td>
+    <td>{{ e.muscle_group }}</td>
+    <td>
       <form method="post" style="display:inline">
         <input type="hidden" name="delete_id" value="{{ e.id }}">
         <button type="submit" onclick="return confirm('本当にこの種目を削除しますか？')">削除</button>
       </form>
-    </li>
+    </td>
+  </tr>
   {% endfor %}
-</ul>
+</table>
 
 <h2>新しいエクササイズを追加</h2>
 <form method="post">

--- a/templates/index.html
+++ b/templates/index.html
@@ -31,12 +31,12 @@
     <td>{{ w.sets }}</td>
     <td>{{ w.reps }}</td>
     <td>{{ w.weight }}</td>
-    <td>
-      <!-- 削除ボタン -->
-      <form method="post" action="{{ url_for('delete_workout', wid=w.id) }}" style="display:inline">
-        <button type="submit" onclick="return confirm('本当にこのログを削除しますか？')">削除</button>
-      </form>
-    </td>
+      <td>
+        <a href="{{ url_for('edit_workout', wid=w.id) }}">編集</a>
+        <form method="post" action="{{ url_for('delete_workout', wid=w.id) }}" style="display:inline">
+          <button type="submit" onclick="return confirm('本当にこのログを削除しますか？')">削除</button>
+        </form>
+      </td>
   </tr>
   {% endfor %}
 </table>

--- a/templates/log.html
+++ b/templates/log.html
@@ -3,16 +3,34 @@
 {% block content %}
 <h1>トレーニングログを記録</h1>
 <form method="post">
-  日付：<input type="date" name="date"><br><br>
-  種目：
-  <select name="exercise_id">
-    {% for e in exercises %}
-      <option value="{{ e.id }}">{{ e.name }}（{{ e.muscle_group }}）</option>
-    {% endfor %}
-  </select><br><br>
-  セット数：<input type="number" name="sets" value="3" required><br><br>
-  回数：<input type="number" name="reps" value="10" required><br><br>
-  重量(kg)：<input type="number" name="weight" step="2" value="0" required><br><br>
+  <table>
+    <tr>
+      <td>日付：</td>
+      <td><input type="date" name="date"></td>
+    </tr>
+    <tr>
+      <td>種目：</td>
+      <td>
+        <select name="exercise_id">
+          {% for e in exercises %}
+            <option value="{{ e.id }}">{{ e.name }}（{{ e.muscle_group }}）</option>
+          {% endfor %}
+        </select>
+      </td>
+    </tr>
+    <tr>
+      <td>セット数：</td>
+      <td><input type="number" name="sets" value="3" required></td>
+    </tr>
+    <tr>
+      <td>回数：</td>
+      <td><input type="number" name="reps" value="10" required></td>
+    </tr>
+    <tr>
+      <td>重量(kg)：</td>
+      <td><input type="number" name="weight" step="2" value="0" required></td>
+    </tr>
+  </table>
   <button type="submit">記録</button>
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow editing workouts from the history table
- add calendar view for workout history
- display exercise list in a table with sequential numbering
- align log record inputs and colon positions using a table
- style adjustments for new calendar view

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_683f917e09e483248f5198243c85cdb5