### PR TITLE
Improve calendar and exercises UI

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -2,21 +2,16 @@ document.addEventListener('DOMContentLoaded', function() {
   // Auto-fill today's date on log page
   var dateInput = document.getElementById('dateInput');
   if (dateInput && !dateInput.value) {
-    var today = new Date().toISOString().slice(0, 10);
-    dateInput.value = today;
+    dateInput.value = new Date().toISOString().slice(0,10);
   }
 
   // Filter workouts by muscle group
   var filter = document.getElementById('muscleFilter');
-  if (filter) {
-    filter.addEventListener('change', function() {
-      var value = this.value;
-      document.querySelectorAll('#workoutTable tbody tr').forEach(function(row) {
-        if (!value || row.dataset.muscle === value) {
-          row.style.display = '';
-        } else {
-          row.style.display = 'none';
-        }
+  if(filter){
+    filter.addEventListener('change', function(){
+      var val = this.value;
+      document.querySelectorAll('#workoutTable tbody tr').forEach(function(row){
+        row.style.display = (!val || row.dataset.muscle === val) ? '' : 'none';
       });
     });
   }
@@ -24,28 +19,94 @@ document.addEventListener('DOMContentLoaded', function() {
   // Toggle new exercise form
   var toggleFormBtn = document.getElementById('toggleForm');
   var exerciseForm = document.getElementById('exerciseForm');
-  if (toggleFormBtn && exerciseForm) {
-    toggleFormBtn.addEventListener('click', function() {
-      if (exerciseForm.style.display === 'none' || exerciseForm.style.display === '') {
-        exerciseForm.style.display = 'block';
-      } else {
-        exerciseForm.style.display = 'none';
-      }
+  var cancelAdd = document.getElementById('cancelAdd');
+  if(toggleFormBtn && exerciseForm){
+    toggleFormBtn.addEventListener('click', function(){
+      exerciseForm.style.display = (exerciseForm.style.display === 'block') ? 'none' : 'block';
+    });
+  }
+  if(cancelAdd && exerciseForm){
+    cancelAdd.addEventListener('click', function(){
+      exerciseForm.style.display = 'none';
     });
   }
 
   // Add new log entry
   var addEntryBtn = document.getElementById('addEntry');
   var entriesDiv = document.getElementById('entries');
-  if (addEntryBtn && entriesDiv) {
-    addEntryBtn.addEventListener('click', function() {
+  if(addEntryBtn && entriesDiv){
+    addEntryBtn.addEventListener('click', function(){
       var first = entriesDiv.querySelector('.entry');
-      if (first) {
+      if(first){
         var clone = first.cloneNode(true);
-        clone.querySelectorAll('input').forEach(function(inp) { inp.value = inp.defaultValue; });
-        clone.querySelectorAll('select').forEach(function(sel) { sel.selectedIndex = 0; });
+        clone.querySelectorAll('input').forEach(function(inp){ inp.value = inp.defaultValue; });
+        clone.querySelectorAll('select').forEach(function(sel){ sel.selectedIndex = 0; });
+        var rm = document.createElement('button');
+        rm.type = 'button';
+        rm.textContent = '削除';
+        rm.className = 'removeEntry';
+        clone.appendChild(rm);
         entriesDiv.appendChild(clone);
       }
     });
   }
+
+  document.addEventListener('click', function(e){
+    if(e.target.classList.contains('removeEntry')){
+      e.target.parentElement.remove();
+    }
+  });
+
+  // allow manual weight input
+  var logForm = document.getElementById('logForm');
+  if(logForm){
+    logForm.addEventListener('submit', function(){
+      document.querySelectorAll('input[name="weight"]').forEach(function(inp){
+        inp.removeAttribute('step');
+      });
+    });
+  }
+
+  // modal handling
+  var modal = document.getElementById('modal');
+  var modalBody = document.getElementById('modalBody');
+  if(modal){
+    modal.querySelector('.close').addEventListener('click', function(){
+      modal.style.display = 'none';
+    });
+  }
+
+  // calendar popup
+  document.querySelectorAll('.calendar td[data-date]').forEach(function(td){
+    td.addEventListener('click', function(){
+      var date = this.dataset.date;
+      fetch('/day_data/' + date)
+        .then(r => r.json())
+        .then(function(data){
+          if(!data.length){
+            modalBody.innerHTML = '<p>記録がありません。</p>';
+          }else{
+            var html = '<table><tr><th>種目</th><th>部位</th><th>セット</th><th>回数</th><th>重量</th></tr>';
+            data.forEach(function(row){
+              html += '<tr><td>'+row.name+'</td><td>'+row.muscle_group+'</td><td>'+row.sets+'</td><td>'+row.reps+'</td><td>'+row.weight+'</td></tr>';
+            });
+            html += '</table>';
+            modalBody.innerHTML = '<h3>'+date+'</h3>' + html;
+          }
+          modal.style.display = 'flex';
+        });
+    });
+  });
+
+  // exercise note popup
+  document.querySelectorAll('.exercise-note').forEach(function(el){
+    el.addEventListener('click', function(e){
+      var note = this.dataset.note;
+      if(note){
+        modalBody.innerHTML = '<p>'+note+'</p>';
+        modal.style.display = 'flex';
+      }
+      e.preventDefault();
+    });
+  });
 });

--- a/static/style.css
+++ b/static/style.css
@@ -60,6 +60,7 @@ button {
   height: 80px;
   vertical-align: top;
   position: relative;
+  width: 14.28%;
 }
 
 .calendar td.today {
@@ -87,6 +88,7 @@ button {
   margin-bottom: 2px;
   padding: 2px;
   border-radius: 2px;
+  white-space: nowrap;
 }
 
 .calendar-nav {
@@ -104,6 +106,9 @@ button {
   text-decoration: none;
   color: inherit;
   display: block;
+  width: 100%;
+  height: 100%;
+  padding: 4px;
 }
 
 .submit-btn {
@@ -115,5 +120,30 @@ button {
   color: #fff;
   border: none;
   border-radius: 4px;
+  cursor: pointer;
+}
+
+.modal {
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0,0,0,0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal-content {
+  background: #fff;
+  padding: 20px;
+  border-radius: 4px;
+  max-width: 400px;
+  width: 90%;
+}
+
+.close {
+  float: right;
   cursor: pointer;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,6 +14,12 @@
   </nav>
   <hr>
   {% block content %}{% endblock %}
+  <div id="modal" class="modal" style="display:none;">
+    <div class="modal-content">
+      <span class="close">&times;</span>
+      <div id="modalBody"></div>
+    </div>
+  </div>
   <script src="{{ url_for('static', filename='script.js') }}"></script>
 </body>
 </html>

--- a/templates/calendar.html
+++ b/templates/calendar.html
@@ -8,20 +8,20 @@
 </div>
 <table class="calendar">
   <tr>
+    <th>日</th>
     <th>月</th>
     <th>火</th>
     <th>水</th>
     <th>木</th>
     <th>金</th>
     <th>土</th>
-    <th>日</th>
   </tr>
   {% for week in days %}
   <tr>
       {% for day in week %}
       {% set date_str = day.strftime('%Y-%m-%d') %}
-      <td class="{% if day.month != month %}other-month {% endif %}{% if day == today %}today {% endif %}{% if events.get(date_str) %}has-event{% endif %}">
-        <div class="date-number"><a href="{{ url_for('day_detail', date=date_str) }}" class="day-link">{{ day.day }}</a></div>
+      <td class="{% if day.month != month %}other-month {% endif %}{% if day == today %}today {% endif %}{% if events.get(date_str) %}has-event{% endif %}" data-date="{{ date_str }}">
+        <div class="date-number"><a href="#" class="day-link">{{ day.day }}</a></div>
         {% set day_events = events.get(date_str, []) %}
         {% if day_events %}
         <ul class="events">

--- a/templates/edit_exercise.html
+++ b/templates/edit_exercise.html
@@ -1,0 +1,31 @@
+{% extends 'base.html' %}
+{% block title %}エクササイズ編集{% endblock %}
+{% block content %}
+<h1>エクササイズを編集</h1>
+<form method="post">
+  <table>
+    <tr>
+      <td>名前：</td>
+      <td><input type="text" name="name" value="{{ exercise.name }}" required></td>
+    </tr>
+    <tr>
+      <td>部位：</td>
+      <td>
+        <select name="muscle_group">
+          <option value="胸" {% if exercise.muscle_group == '胸' %}selected{% endif %}>胸</option>
+          <option value="背中" {% if exercise.muscle_group == '背中' %}selected{% endif %}>背中</option>
+          <option value="脚" {% if exercise.muscle_group == '脚' %}selected{% endif %}>脚</option>
+          <option value="肩" {% if exercise.muscle_group == '肩' %}selected{% endif %}>肩</option>
+          <option value="腕" {% if exercise.muscle_group == '腕' %}selected{% endif %}>腕</option>
+          <option value="腹" {% if exercise.muscle_group == '腹' %}selected{% endif %}>腹</option>
+        </select>
+      </td>
+    </tr>
+    <tr>
+      <td>備考：</td>
+      <td><input type="text" name="note" value="{{ exercise.note }}"></td>
+    </tr>
+  </table>
+  <button type="submit">更新</button>
+</form>
+{% endblock %}

--- a/templates/exercises.html
+++ b/templates/exercises.html
@@ -15,7 +15,9 @@
       <option>腕</option>
       <option>腹</option>
     </select>
+    備考：<input type="text" name="note">
     <button type="submit">追加</button>
+    <button type="button" id="cancelAdd">キャンセル</button>
   </form>
 </div>
 
@@ -47,10 +49,11 @@
   </tr>
   {% for e in exercises %}
   <tr>
-    <td>{{ loop.index }}</td>
-    <td>{{ e.name }}</td>
+    <td>{{ numbers[e.id] }}</td>
+    <td><a href="#" class="exercise-note" data-note="{{ e.note|default('') }}">{{ e.name }}</a></td>
     <td>{{ e.muscle_group }}</td>
     <td>
+      <a href="{{ url_for('edit_exercise', eid=e.id) }}">編集</a>
       <form method="post" style="display:inline">
         <input type="hidden" name="delete_id" value="{{ e.id }}">
         <button type="submit" onclick="return confirm('本当にこの種目を削除しますか？')">削除</button>

--- a/templates/log.html
+++ b/templates/log.html
@@ -36,6 +36,7 @@
           <td><input type="number" name="weight" step="2" value="0" required></td>
         </tr>
       </table>
+      <button type="button" class="removeEntry">削除</button>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- start calendar weeks on Sunday
- keep calendar column width fixed and open day details in a modal
- enlarge day click area
- allow editing exercises, add notes and cancel button
- show exercise notes in popup
- add ability to remove log entries
- allow manual weight entry despite 2kg step
- add modal HTML and styles

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_683fbcbc7c4c8324be1e23250ad1b1af