### PR TITLE
Fix UI details

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -146,4 +146,5 @@ button {
 .close {
   float: right;
   cursor: pointer;
+  font-size: 1.5em;
 }

--- a/templates/exercises.html
+++ b/templates/exercises.html
@@ -53,7 +53,7 @@
     <td><a href="#" class="exercise-note" data-note="{{ e.note|default('') }}">{{ e.name }}</a></td>
     <td>{{ e.muscle_group }}</td>
     <td>
-      <a href="{{ url_for('edit_exercise', eid=e.id) }}">編集</a>
+      <a href="{{ url_for('edit_exercise', eid=e.id) }}" class="button-link">編集</a>
       <form method="post" style="display:inline">
         <input type="hidden" name="delete_id" value="{{ e.id }}">
         <button type="submit" onclick="return confirm('本当にこの種目を削除しますか？')">削除</button>

--- a/templates/log.html
+++ b/templates/log.html
@@ -36,7 +36,6 @@
           <td><input type="number" name="weight" step="2" value="0" required></td>
         </tr>
       </table>
-      <button type="button" class="removeEntry">削除</button>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- enlarge modal close button in the calendar popup
- show edit links as buttons on the exercise list
- remove delete button from initial log entry so additional entries only get one delete button each

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6840d73803288324b8043b82e29554fc