### PR TITLE
Enable clickable URLs in exercise notes

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -128,7 +128,12 @@ document.addEventListener('DOMContentLoaded', function() {
     el.addEventListener('click', function(e){
       var note = this.dataset.note;
       if(note){
-        modalBody.innerHTML = '<p>'+note+'</p>';
+        var trimmed = note.trim();
+        if(/^https?:\/\//.test(trimmed)){
+          modalBody.innerHTML = '<p><a href="'+trimmed+'" target="_blank" rel="noopener noreferrer">'+trimmed+'</a></p>';
+        }else{
+          modalBody.innerHTML = '<p>'+trimmed+'</p>';
+        }
         modal.style.display = 'flex';
       }
       e.preventDefault();


### PR DESCRIPTION
## Summary
- improve exercise note popup to detect URLs and make them clickable

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6840e7a855a48324b33634cedb2a48bc