### PR TITLE
Update design to dark dashboard style

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,32 +1,50 @@
 body {
   font-family: Arial, sans-serif;
-  max-width: 800px;
-  margin: 20px auto;
+  background-color: #121212;
+  color: #e0e0e0;
   line-height: 1.6;
 }
 
+.container {
+  max-width: 1100px;
+  margin: 20px auto;
+  padding: 0 16px;
+}
+
+nav {
+  display: flex;
+  gap: 16px;
+  justify-content: center;
+  margin-bottom: 20px;
+}
+
 nav a {
-  margin: 0 8px;
   text-decoration: none;
-  color: #007acc;
+  color: #26a69a;
+}
+
+nav a:hover {
+  text-decoration: underline;
 }
 
 table {
   width: 100%;
   border-collapse: collapse;
   margin-top: 16px;
+  background-color: #1e1e1e;
 }
 
 th,
 td {
-  border: 1px solid #ddd;
+  border: 1px solid #333;
   padding: 8px;
   text-align: center;
+  color: #e0e0e0;
 }
 
 h1,
 h2 {
-  color: #333;
+  color: #fff;
 }
 
 button {
@@ -36,14 +54,22 @@ button {
 
 .button-link {
   padding: 6px 12px;
-  background-color: #007acc;
+  background-color: #26a69a;
   color: #fff;
   text-decoration: none;
   border-radius: 4px;
 }
 
+button,
+.submit-btn {
+  background-color: #26a69a;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+}
+
 .other-month {
-  background-color: #f0f0f0;
+  background-color: #2b2b2b;
 }
 .calendar {
   width: 100%;
@@ -52,7 +78,7 @@ button {
 }
 
 .calendar th {
-  background-color: #007acc;
+  background-color: #009688;
   color: #fff;
 }
 
@@ -61,19 +87,23 @@ button {
   vertical-align: top;
   position: relative;
   width: 14.28%;
+  background-color: #1e1e1e;
+  border: 1px solid #333;
+  color: #e0e0e0;
 }
 
 .calendar td.today {
-  background-color: #fff7e6;
-  border: 2px solid #ff9800;
+  background-color: #333;
+  border: 2px solid #26a69a;
 }
 
 .calendar td.has-event {
-  background-color: #eaf6ff;
+  background-color: #2b2b2b;
 }
 
 .date-number {
   font-weight: bold;
+  color: #fff;
 }
 
 .events {
@@ -84,11 +114,12 @@ button {
 }
 
 .events li {
-  background-color: #f4f4f4;
+  background-color: #444;
   margin-bottom: 2px;
   padding: 2px;
   border-radius: 2px;
   white-space: nowrap;
+  color: #e0e0e0;
 }
 
 .calendar-nav {
@@ -99,7 +130,7 @@ button {
 .calendar-nav a {
   margin: 0 10px;
   text-decoration: none;
-  color: #007acc;
+  color: #26a69a;
 }
 
 .day-link {
@@ -116,10 +147,6 @@ button {
   margin: 16px auto;
   padding: 10px 20px;
   font-size: 1.2em;
-  background-color: #007acc;
-  color: #fff;
-  border: none;
-  border-radius: 4px;
   cursor: pointer;
 }
 
@@ -136,7 +163,8 @@ button {
 }
 
 .modal-content {
-  background: #fff;
+  background: #2b2b2b;
+  color: #e0e0e0;
   padding: 20px;
   border-radius: 4px;
   max-width: 400px;

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,13 +7,14 @@
 </head>
 <body>
   <nav>
-    <a href="{{ url_for('index') }}">履歴</a> |
-    <a href="{{ url_for('calendar_view') }}">カレンダー</a> |
-    <a href="{{ url_for('exercises') }}">エクササイズ管理</a> |
+    <a href="{{ url_for('index') }}">履歴</a>
+    <a href="{{ url_for('calendar_view') }}">カレンダー</a>
+    <a href="{{ url_for('exercises') }}">エクササイズ管理</a>
     <a href="{{ url_for('log') }}">ログ記録</a>
   </nav>
-  <hr>
-  {% block content %}{% endblock %}
+  <div class="container">
+    {% block content %}{% endblock %}
+  </div>
   <div id="modal" class="modal" style="display:none;">
     <div class="modal-content">
       <span class="close">&times;</span>

--- a/templates/calendar.html
+++ b/templates/calendar.html
@@ -26,7 +26,7 @@
         {% if day_events %}
         <ul class="events">
           {% for name in day_events %}
-          <li style="background-color:{% if name == '胸' %}#fddede{% elif name == '背中' %}#defdfd{% elif name == '脚' %}#e0f2e9{% elif name == '肩' %}#fdf7de{% elif name == '腕' %}#fce4ec{% elif name == '腹' %}#f0f0f0{% else %}#ffffff{% endif %};">{{ name }}</li>
+          <li style="background-color:{% if name == '胸' %}#4a3b3b{% elif name == '背中' %}#3b4a4a{% elif name == '脚' %}#3b4a3b{% elif name == '肩' %}#4a4a3b{% elif name == '腕' %}#4a3b4a{% elif name == '腹' %}#3b3b4a{% else %}#2c2c2c{% endif %}; color:#e0e0e0;">{{ name }}</li>
           {% endfor %}
         </ul>
         {% endif %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,13 +27,13 @@
   </tr>
   {% for w in workouts %}
   <tr data-muscle="{{ w.muscle_group }}" style="background-color:
-      {% if w.muscle_group == '胸' %}#fddede
-      {% elif w.muscle_group == '背中' %}#defdfd
-      {% elif w.muscle_group == '脚' %}#e0f2e9
-      {% elif w.muscle_group == '肩' %}#fdf7de
-      {% elif w.muscle_group == '腕' %}#fce4ec
-      {% elif w.muscle_group == '腹' %}#f0f0f0
-      {% else %}#ffffff
+      {% if w.muscle_group == '胸' %}#4a3b3b
+      {% elif w.muscle_group == '背中' %}#3b4a4a
+      {% elif w.muscle_group == '脚' %}#3b4a3b
+      {% elif w.muscle_group == '肩' %}#4a4a3b
+      {% elif w.muscle_group == '腕' %}#4a3b4a
+      {% elif w.muscle_group == '腹' %}#3b3b4a
+      {% else %}#2c2c2c
       {% endif %};
     ">
     <td>{{ w.date }}</td>


### PR DESCRIPTION
## Summary
- apply dark themed CSS with teal accent and ample spacing
- wrap page content in container layout
- set dashboard colors for workout rows and calendar events

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840f76aff288324a6c745a56c09b523