### PR TITLE
Add Japanese comments

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -1,11 +1,12 @@
+// ページ読み込み後に各種処理を設定
 document.addEventListener('DOMContentLoaded', function() {
-  // Auto-fill today's date on log page
+  // ログ入力ページの日付を自動で本日にする
   var dateInput = document.getElementById('dateInput');
   if (dateInput && !dateInput.value) {
     dateInput.value = new Date().toISOString().slice(0,10);
   }
 
-  // Filter workouts by muscle group
+  // 部位フィルターによる表示切り替え
   var filter = document.getElementById('muscleFilter');
   if(filter){
     filter.addEventListener('change', function(){
@@ -16,7 +17,7 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   }
 
-  // Toggle new exercise form
+  // 新しいエクササイズ入力フォームの表示切替
   var toggleFormBtn = document.getElementById('toggleForm');
   var exerciseForm = document.getElementById('exerciseForm');
   var cancelAdd = document.getElementById('cancelAdd');
@@ -31,7 +32,7 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   }
 
-  // Add new log entry
+  // 種目入力欄をもう一行追加
   var addEntryBtn = document.getElementById('addEntry');
   var entriesDiv = document.getElementById('entries');
   if(addEntryBtn && entriesDiv){
@@ -57,7 +58,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
   });
 
-  // allow manual weight input
+  // 重量欄の手入力を許可
   var logForm = document.getElementById('logForm');
   if(logForm){
     logForm.addEventListener('submit', function(){
@@ -67,7 +68,7 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   }
 
-  // modal handling
+  // モーダルの表示・非表示を制御
   var modal = document.getElementById('modal');
   var modalBody = document.getElementById('modalBody');
   if(modal){
@@ -81,7 +82,7 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   }
 
-  // calendar popup
+  // カレンダーの日付をクリックしたときのポップアップ
   document.querySelectorAll('.calendar td[data-date]').forEach(function(td){
     td.addEventListener('click', function(){
       var date = this.dataset.date;
@@ -103,7 +104,7 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   });
 
-  // edit workout popup
+  // 編集ボタンを押したときのワークアウト編集モーダル
   document.querySelectorAll('.edit-workout').forEach(function(el){
     el.addEventListener('click', function(e){
       e.preventDefault();
@@ -123,7 +124,7 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   });
 
-  // exercise memo popup
+  // 種目名クリックでメモを表示
   document.querySelectorAll('.exercise-note').forEach(function(el){
     el.addEventListener('click', function(e){
       var memo = this.dataset.memo;
@@ -144,7 +145,7 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   });
 
-  // edit exercise popup
+  // エクササイズ編集モーダル
   document.querySelectorAll('.edit-exercise').forEach(function(el){
     el.addEventListener('click', function(e){
       e.preventDefault();
@@ -164,3 +165,4 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   });
 });
+// ここまでJavaScriptの処理

--- a/static/style.css
+++ b/static/style.css
@@ -1,3 +1,5 @@
+/* このCSSファイルではアプリ全体の見た目を定義します */
+/* サイト全体の基本スタイル */
 body {
   font-family: Arial, sans-serif;
   background-color: #121212;
@@ -71,6 +73,7 @@ button,
 .other-month {
   background-color: #2b2b2b;
 }
+/* カレンダーの表示レイアウト */
 .calendar {
   width: 100%;
   border-collapse: collapse;
@@ -150,6 +153,7 @@ button,
   cursor: pointer;
 }
 
+/* ポップアップ用モーダルのスタイル */
 .modal {
   position: fixed;
   left: 0;

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,9 +3,11 @@
 <head>
   <meta charset="UTF-8">
   <title>{% block title %}筋トレアプリ{% endblock %}</title>
+  <!-- CSS を読み込む -->
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>
+  <!-- 画面上部のナビゲーションメニュー -->
   <nav>
     <a href="{{ url_for('index') }}">履歴</a>
     <a href="{{ url_for('calendar_view') }}">カレンダー</a>
@@ -15,12 +17,14 @@
   <div class="container">
     {% block content %}{% endblock %}
   </div>
+  <!-- ポップアップ表示用のモーダル -->
   <div id="modal" class="modal" style="display:none;">
     <div class="modal-content">
       <span class="close">&times;</span>
       <div id="modalBody"></div>
     </div>
   </div>
+  <!-- JavaScript を読み込む -->
   <script src="{{ url_for('static', filename='script.js') }}"></script>
 </body>
 </html>

--- a/templates/calendar.html
+++ b/templates/calendar.html
@@ -2,10 +2,12 @@
 {% block title %}カレンダー{% endblock %}
 {% block content %}
 <h1>{{ year }}年{{ month }}月</h1>
+<!-- 月移動用リンク -->
 <div class="calendar-nav">
   <a href="{{ url_for('calendar_view', year=prev_year, month=prev_month) }}">&laquo; 前月</a> |
   <a href="{{ url_for('calendar_view', year=next_year, month=next_month) }}">翌月 &raquo;</a>
 </div>
+<!-- カレンダー本体 -->
 <table class="calendar">
   <tr>
     <th>日</th>

--- a/templates/day_detail.html
+++ b/templates/day_detail.html
@@ -2,6 +2,7 @@
 {% block title %}{{ date }} のトレーニング{% endblock %}
 {% block content %}
 <h1>{{ date }} のトレーニング</h1>
+<!-- 1日の詳細ログ表示 -->
 {% if workouts %}
 <table>
   <tr>
@@ -22,6 +23,7 @@
   {% endfor %}
 </table>
 {% else %}
+<!-- その日の記録が無い場合 -->
 <p>記録がありません。</p>
 {% endif %}
 {% endblock %}

--- a/templates/edit_exercise.html
+++ b/templates/edit_exercise.html
@@ -2,6 +2,7 @@
 {% block title %}エクササイズ編集{% endblock %}
 {% block content %}
 <h1>エクササイズを編集</h1>
+<!-- 選択した種目の内容を更新するフォーム -->
 <form method="post">
   <table>
     <tr>

--- a/templates/edit_exercise_form.html
+++ b/templates/edit_exercise_form.html
@@ -1,4 +1,5 @@
 <h1>エクササイズを編集</h1>
+<!-- モーダル用の編集フォーム -->
 <form method="post" id="editExerciseForm">
   <table>
     <tr>

--- a/templates/edit_workout.html
+++ b/templates/edit_workout.html
@@ -2,6 +2,7 @@
 {% block title %}ログ編集{% endblock %}
 {% block content %}
 <h1>ログを編集</h1>
+<!-- ワークアウトの詳細を変更するフォーム -->
 <form method="post" id="editWorkoutForm">
   <table>
     <tr>

--- a/templates/edit_workout_form.html
+++ b/templates/edit_workout_form.html
@@ -1,4 +1,5 @@
 <h1>ログを編集</h1>
+<!-- モーダル表示用の編集フォーム -->
 <form method="post" id="editWorkoutForm">
   <table>
     <tr>

--- a/templates/exercises.html
+++ b/templates/exercises.html
@@ -2,6 +2,7 @@
 {% block title %}エクササイズ管理{% endblock %}
 {% block content %}
 <h1>エクササイズ管理</h1>
+<!-- 新しい種目を登録するフォーム -->
 <h2><button type="button" id="toggleForm">新しいエクササイズを追加</button></h2>
 <div id="exerciseForm" style="display:none;">
   <form method="post">
@@ -22,6 +23,7 @@
   </form>
 </div>
 
+<!-- 表示の並び替えと部位フィルター -->
 <form method="get" style="margin-top: 10px;">
   並び順：
   <select name="sort">
@@ -41,6 +43,7 @@
   <button type="submit">適用</button>
 </form>
 
+<!-- 登録済みのエクササイズ一覧 -->
 <table>
   <tr>
     <th>番号</th>

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,6 +2,7 @@
 {% block title %}トレーニング履歴{% endblock %}
 {% block content %}
 <h1>トレーニング履歴</h1>
+<!-- 部位ごとの絞り込みプルダウン -->
 
 <label for="muscleFilter">部位フィルター:</label>
 <select id="muscleFilter">
@@ -15,6 +16,7 @@
 </select>
 
 {% if workouts %}
+<!-- ログがある場合はテーブルで表示 -->
 <table id="workoutTable">
   <tr>
     <th>日付</th>
@@ -52,6 +54,7 @@
   {% endfor %}
 </table>
 {% else %}
+<!-- ログが無い場合のメッセージ -->
 <p>まだログがありません。<a href="{{ url_for('log') }}">記録しよう</a></p>
 {% endif %}
 

--- a/templates/log.html
+++ b/templates/log.html
@@ -2,6 +2,7 @@
 {% block title %}ログ記録{% endblock %}
 {% block content %}
 <h1>トレーニングログを記録</h1>
+<!-- ここで新しいトレーニング内容を入力します -->
 <form method="post" id="logForm">
   <table>
     <tr>
@@ -10,6 +11,7 @@
     </tr>
   </table>
 
+  <!-- 種目入力欄は複数追加可能 -->
   <div id="entries">
     <div class="entry">
       <table>

--- a/templates/random.html
+++ b/templates/random.html
@@ -2,6 +2,7 @@
 {% block title %}ランダムメニュー{% endblock %}
 {% block content %}
 <h1>本日のランダムメニュー</h1>
+<!-- 登録された種目からランダムに表示 -->
 {% if workout %}
 <ol>
   {% for w in workout %}


### PR DESCRIPTION
## Summary
- add Japanese comments to Flask app
- document HTML templates in Japanese
- note styles and scripts with helpful Japanese comments

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68410028f1308324b87b1df29b023f45