### PR TITLE
Add exercise defaults and filtering

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -6,14 +6,24 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   // Filter workouts by muscle group
-  var filter = document.getElementById('muscleFilter');
-  if(filter){
-    filter.addEventListener('change', function(){
-      var val = this.value;
-      document.querySelectorAll('#workoutTable tbody tr').forEach(function(row){
-        row.style.display = (!val || row.dataset.muscle === val) ? '' : 'none';
-      });
+  var muscleFilter = document.getElementById('muscleFilter');
+  var exerciseFilter = document.getElementById('exerciseFilter');
+
+  function updateFilters(){
+    var mVal = muscleFilter ? muscleFilter.value : '';
+    var eVal = exerciseFilter ? exerciseFilter.value : '';
+    document.querySelectorAll('#workoutTable tbody tr').forEach(function(row){
+      var okMuscle = !mVal || row.dataset.muscle === mVal;
+      var okEx = !eVal || row.dataset.exercise === eVal;
+      row.style.display = (okMuscle && okEx) ? '' : 'none';
     });
+  }
+
+  if(muscleFilter){
+    muscleFilter.addEventListener('change', updateFilters);
+  }
+  if(exerciseFilter){
+    exerciseFilter.addEventListener('change', updateFilters);
   }
 
   // Toggle new exercise form
@@ -34,20 +44,47 @@ document.addEventListener('DOMContentLoaded', function() {
   // Add new log entry
   var addEntryBtn = document.getElementById('addEntry');
   var entriesDiv = document.getElementById('entries');
+
+  function attachExerciseListener(entry){
+    var select = entry.querySelector('.exercise-select');
+    if(select){
+      select.addEventListener('change', function(){
+        var opt = this.options[this.selectedIndex];
+        var sets = opt.dataset.sets;
+        var reps = opt.dataset.reps;
+        var weight = opt.dataset.weight;
+        if(sets){ entry.querySelector('input[name="sets"]').value = sets; }
+        if(reps){ entry.querySelector('input[name="reps"]').value = reps; }
+        if(weight){ entry.querySelector('input[name="weight"]').value = weight; }
+      });
+    }
+  }
+
   if(addEntryBtn && entriesDiv){
     addEntryBtn.addEventListener('click', function(){
       var first = entriesDiv.querySelector('.entry');
       if(first){
         var clone = first.cloneNode(true);
         clone.querySelectorAll('input').forEach(function(inp){ inp.value = inp.defaultValue; });
-        clone.querySelectorAll('select').forEach(function(sel){ sel.selectedIndex = 0; });
+        clone.querySelectorAll('select').forEach(function(sel){
+          var def = Array.from(sel.options).findIndex(function(o){ return o.defaultSelected; });
+          sel.selectedIndex = def >= 0 ? def : 0;
+        });
         var rm = document.createElement('button');
         rm.type = 'button';
         rm.textContent = '削除';
         rm.className = 'removeEntry';
         clone.appendChild(rm);
         entriesDiv.appendChild(clone);
+        attachExerciseListener(clone);
       }
+    });
+  }
+
+  // attach listener for initial entry
+  if(entriesDiv){
+    entriesDiv.querySelectorAll('.entry').forEach(function(entry){
+      attachExerciseListener(entry);
     });
   }
 

--- a/templates/edit_exercise.html
+++ b/templates/edit_exercise.html
@@ -29,6 +29,18 @@
       <td>動画URL：</td>
       <td><input type="url" name="video_url" value="{{ exercise.video_url }}"></td>
     </tr>
+    <tr>
+      <td>セット数デフォルト：</td>
+      <td><input type="number" name="default_sets" value="{{ exercise.default_sets }}" min="1"></td>
+    </tr>
+    <tr>
+      <td>回数デフォルト：</td>
+      <td><input type="number" name="default_reps" value="{{ exercise.default_reps }}" min="1"></td>
+    </tr>
+    <tr>
+      <td>重量デフォルト(kg)：</td>
+      <td><input type="number" name="default_weight" value="{{ exercise.default_weight }}" step="0.1"></td>
+    </tr>
   </table>
   <button type="submit">更新</button>
 </form>

--- a/templates/edit_exercise_form.html
+++ b/templates/edit_exercise_form.html
@@ -26,6 +26,18 @@
       <td>動画URL：</td>
       <td><input type="url" name="video_url" value="{{ exercise.video_url }}"></td>
     </tr>
+    <tr>
+      <td>セット数デフォルト：</td>
+      <td><input type="number" name="default_sets" value="{{ exercise.default_sets }}" min="1"></td>
+    </tr>
+    <tr>
+      <td>回数デフォルト：</td>
+      <td><input type="number" name="default_reps" value="{{ exercise.default_reps }}" min="1"></td>
+    </tr>
+    <tr>
+      <td>重量デフォルト(kg)：</td>
+      <td><input type="number" name="default_weight" value="{{ exercise.default_weight }}" step="0.1"></td>
+    </tr>
   </table>
   <button type="submit">更新</button>
 </form>

--- a/templates/exercises.html
+++ b/templates/exercises.html
@@ -17,6 +17,9 @@
     </select>
     メモ：<input type="text" name="memo">
     動画URL：<input type="url" name="video_url">
+    セット数デフォルト：<input type="number" name="default_sets" min="1">
+    回数デフォルト：<input type="number" name="default_reps" min="1">
+    重量デフォルト(kg)：<input type="number" name="default_weight" step="0.1">
     <button type="submit">追加</button>
     <button type="button" id="cancelAdd">キャンセル</button>
   </form>

--- a/templates/index.html
+++ b/templates/index.html
@@ -13,6 +13,13 @@
   <option value="腕">腕</option>
   <option value="腹">腹</option>
 </select>
+<label for="exerciseFilter">種目フィルター:</label>
+<select id="exerciseFilter">
+  <option value="">全て</option>
+  {% for ex in exercises %}
+    <option value="{{ ex.name }}">{{ ex.name }}</option>
+  {% endfor %}
+</select>
 
 {% if workouts %}
 <table id="workoutTable">
@@ -26,7 +33,7 @@
     <th>操作</th>
   </tr>
   {% for w in workouts %}
-  <tr data-muscle="{{ w.muscle_group }}" style="background-color:
+  <tr data-muscle="{{ w.muscle_group }}" data-exercise="{{ w.exercise }}" style="background-color:
       {% if w.muscle_group == '胸' %}#fddede
       {% elif w.muscle_group == '背中' %}#defdfd
       {% elif w.muscle_group == '脚' %}#e0f2e9

--- a/templates/log.html
+++ b/templates/log.html
@@ -16,9 +16,9 @@
         <tr>
           <td>種目：</td>
           <td>
-            <select name="exercise_id">
+            <select name="exercise_id" class="exercise-select">
               {% for e in exercises %}
-                <option value="{{ e.id }}">{{ e.name }}（{{ e.muscle_group }}）</option>
+                <option value="{{ e.id }}" data-sets="{{ e.default_sets }}" data-reps="{{ e.default_reps }}" data-weight="{{ e.default_weight }}">{{ e.name }}（{{ e.muscle_group }}）</option>
               {% endfor %}
             </select>
           </td>
@@ -40,7 +40,7 @@
           <td>
             <select name="intensity">
               <option value="高い">高い</option>
-              <option value="心地よい">心地よい</option>
+              <option value="心地よい" selected>心地よい</option>
               <option value="低">低</option>
             </select>
           </td>


### PR DESCRIPTION
## Summary
- track default set/reps/weight for each exercise
- allow filtering workout history by exercise name
- enable editing default values for exercises
- autofill defaults when selecting an exercise while logging workouts
- set default intensity to 心地よい and clean JS cloning logic

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68417dd62e4c8324973edc96838c82f9