### PR TITLE
Implement new log modal and UI fixes

### DIFF
--- a/app.py
+++ b/app.py
@@ -269,6 +269,15 @@ def log():
     conn.close()
     return render_template('log.html', exercises=exercises)
 
+@app.route('/log_form')
+def log_form_modal():
+    conn = get_db_connection()
+    exercises = conn.execute(
+        'SELECT * FROM exercises ORDER BY muscle_group ASC, name ASC'
+    ).fetchall()
+    conn.close()
+    return render_template('log_form.html', exercises=exercises)
+
 @app.route('/calendar')
 def calendar_view():
     conn = get_db_connection()

--- a/static/script.js
+++ b/static/script.js
@@ -12,7 +12,7 @@ document.addEventListener('DOMContentLoaded', function() {
   function updateFilters(){
     var mVal = muscleFilter ? muscleFilter.value : '';
     var eVal = exerciseFilter ? exerciseFilter.value : '';
-    document.querySelectorAll('#workoutTable tbody tr').forEach(function(row){
+    document.querySelectorAll('#workoutTable tbody .data-row').forEach(function(row){
       var okMuscle = !mVal || row.dataset.muscle === mVal;
       var okEx = !eVal || row.dataset.exercise === eVal;
       row.style.display = (okMuscle && okEx) ? '' : 'none';
@@ -25,6 +25,16 @@ document.addEventListener('DOMContentLoaded', function() {
   if(exerciseFilter){
     exerciseFilter.addEventListener('change', updateFilters);
   }
+
+  document.querySelectorAll('.exercise-filter-link').forEach(function(el){
+    el.addEventListener('click', function(e){
+      e.preventDefault();
+      if(exerciseFilter){
+        exerciseFilter.value = this.textContent.trim();
+        updateFilters();
+      }
+    });
+  });
 
   // Toggle new exercise form
   var toggleFormBtn = document.getElementById('toggleForm');
@@ -101,6 +111,32 @@ document.addEventListener('DOMContentLoaded', function() {
       document.querySelectorAll('input[name="weight"]').forEach(function(inp){
         inp.removeAttribute('step');
       });
+    });
+  }
+
+  var logModalBtn = document.getElementById('openLogModal');
+  if(logModalBtn){
+    logModalBtn.addEventListener('click', function(){
+      fetch('/log_form')
+        .then(r => r.text())
+        .then(function(html){
+          modalBody.innerHTML = html;
+          modal.style.display = 'flex';
+          var entry = modalBody.querySelector('.entry');
+          if(entry){ attachExerciseListener(entry); }
+          var form = document.getElementById('logFormModal');
+          if(form){
+            var date = form.querySelector('#dateInputModal');
+            if(date && !date.value){
+              date.value = new Date().toISOString().slice(0,10);
+            }
+            form.addEventListener('submit', function(ev){
+              ev.preventDefault();
+              fetch('/log', {method:'POST', body:new FormData(form)})
+                .then(function(){ location.reload(); });
+            });
+          }
+        });
     });
   }
 

--- a/templates/edit_exercise.html
+++ b/templates/edit_exercise.html
@@ -27,7 +27,7 @@
     </tr>
     <tr>
       <td>動画URL：</td>
-      <td><input type="url" name="video_url" value="{{ exercise.video_url }}"></td>
+      <td><input type="text" name="video_url" value="{{ exercise.video_url }}"></td>
     </tr>
     <tr>
       <td>セット数デフォルト：</td>

--- a/templates/edit_exercise_form.html
+++ b/templates/edit_exercise_form.html
@@ -24,7 +24,7 @@
     </tr>
     <tr>
       <td>動画URL：</td>
-      <td><input type="url" name="video_url" value="{{ exercise.video_url }}"></td>
+      <td><input type="text" name="video_url" value="{{ exercise.video_url }}"></td>
     </tr>
     <tr>
       <td>セット数デフォルト：</td>

--- a/templates/exercises.html
+++ b/templates/exercises.html
@@ -16,7 +16,7 @@
       <option>腹</option>
     </select>
     メモ：<input type="text" name="memo">
-    動画URL：<input type="url" name="video_url">
+    動画URL：<input type="text" name="video_url">
     セット数デフォルト：<input type="number" name="default_sets" min="1">
     回数デフォルト：<input type="number" name="default_reps" min="1">
     重量デフォルト(kg)：<input type="number" name="default_weight" step="0.1">
@@ -53,8 +53,8 @@
   </tr>
   {% for e in exercises %}
   <tr>
-    <td>{{ numbers[e.id] }}</td>
-    <td><a href="#" class="exercise-note" data-memo="{{ e.memo|default('') }}" data-video="{{ e.video_url|default('') }}">{{ e.name }}</a></td>
+    <td><a href="#" class="exercise-note" data-memo="{{ e.memo|default('') }}" data-video="{{ e.video_url|default('') }}">{{ numbers[e.id] }}</a></td>
+    <td>{{ e.name }}</td>
     <td>{{ e.muscle_group }}</td>
     <td>
       <a href="#" data-id="{{ e.id }}" class="button-link edit-exercise">編集</a>

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,6 +2,7 @@
 {% block title %}トレーニング履歴{% endblock %}
 {% block content %}
 <h1>トレーニング履歴</h1>
+<button type="button" id="openLogModal">記録</button>
 
 <label for="muscleFilter">部位フィルター:</label>
 <select id="muscleFilter">
@@ -23,17 +24,20 @@
 
 {% if workouts %}
 <table id="workoutTable">
-  <tr>
-    <th>日付</th>
-    <th>種目</th>
-    <th>部位</th>
-    <th>セット</th>
-    <th>回数</th>
-    <th>重量(kg)</th>
-    <th>操作</th>
-  </tr>
+  <thead>
+    <tr>
+      <th>日付</th>
+      <th>種目</th>
+      <th>部位</th>
+      <th>セット</th>
+      <th>回数</th>
+      <th>重量(kg)</th>
+      <th>操作</th>
+    </tr>
+  </thead>
+  <tbody>
   {% for w in workouts %}
-  <tr data-muscle="{{ w.muscle_group }}" data-exercise="{{ w.exercise }}" style="background-color:
+  <tr class="data-row" data-muscle="{{ w.muscle_group }}" data-exercise="{{ w.exercise }}" style="background-color:
       {% if w.muscle_group == '胸' %}#fddede
       {% elif w.muscle_group == '背中' %}#defdfd
       {% elif w.muscle_group == '脚' %}#e0f2e9
@@ -44,7 +48,7 @@
       {% endif %};
     ">
     <td>{{ w.date }}</td>
-    <td>{{ w.exercise }}</td>
+    <td><a href="#" class="exercise-filter-link">{{ w.exercise }}</a></td>
     <td>{{ w.muscle_group }}</td>
     <td>{{ w.sets }}</td>
     <td>{{ w.reps }}</td>
@@ -57,6 +61,7 @@
       </td>
   </tr>
   {% endfor %}
+</tbody>
 </table>
 {% else %}
 <p>まだログがありません。<a href="{{ url_for('log') }}">記録しよう</a></p>

--- a/templates/log.html
+++ b/templates/log.html
@@ -16,7 +16,8 @@
         <tr>
           <td>種目：</td>
           <td>
-            <select name="exercise_id" class="exercise-select">
+            <select name="exercise_id" class="exercise-select" required>
+              <option value="" selected disabled>選択せよ</option>
               {% for e in exercises %}
                 <option value="{{ e.id }}" data-sets="{{ e.default_sets }}" data-reps="{{ e.default_reps }}" data-weight="{{ e.default_weight }}">{{ e.name }}（{{ e.muscle_group }}）</option>
               {% endfor %}

--- a/templates/log_form.html
+++ b/templates/log_form.html
@@ -1,0 +1,50 @@
+<h1>トレーニングログを記録</h1>
+<form method="post" id="logFormModal">
+  <div class="entry">
+    <table>
+      <tr>
+        <td>日付：</td>
+        <td><input type="date" name="date" id="dateInputModal"></td>
+      </tr>
+      <tr>
+        <td>種目：</td>
+        <td>
+          <select name="exercise_id" class="exercise-select" required>
+            <option value="" selected disabled>選択せよ</option>
+            {% for e in exercises %}
+              <option value="{{ e.id }}" data-sets="{{ e.default_sets }}" data-reps="{{ e.default_reps }}" data-weight="{{ e.default_weight }}">{{ e.name }}（{{ e.muscle_group }}）</option>
+            {% endfor %}
+          </select>
+        </td>
+      </tr>
+      <tr>
+        <td>セット数：</td>
+        <td><input type="number" name="sets" value="3" required></td>
+      </tr>
+      <tr>
+        <td>回数：</td>
+        <td><input type="number" name="reps" value="10" required></td>
+      </tr>
+      <tr>
+        <td>重量(kg)：</td>
+        <td><input type="number" name="weight" step="0.1" value="0" required></td>
+      </tr>
+      <tr>
+        <td>強度：</td>
+        <td>
+          <select name="intensity">
+            <option value="高い">高い</option>
+            <option value="心地よい" selected>心地よい</option>
+            <option value="低">低</option>
+          </select>
+        </td>
+      </tr>
+      <tr>
+        <td>備考：</td>
+        <td><input type="text" name="note"></td>
+      </tr>
+    </table>
+  </div>
+  <button type="submit">記録</button>
+</form>
+


### PR DESCRIPTION
## Summary
- set "選択せよ" as default option on log page
- keep table headers while filtering history
- allow filtering by clicking exercise name
- add modal form for adding logs from history page
- show exercise notes via number link
- make video URL optional (text field)

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841837afdf88324aed31ad4717f57c2