### PR TITLE
Add Japanese comments for readability

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -1,15 +1,18 @@
 document.addEventListener('DOMContentLoaded', function() {
-  // Auto-fill today's date on log page
+  // ------- 日付の自動入力 -------
+  // ログ入力フォームの初期値として本日の日付を設定
   var dateInput = document.getElementById('dateInput');
   if (dateInput && !dateInput.value) {
     dateInput.value = new Date().toISOString().slice(0,10);
   }
 
-  // Filter workouts by muscle group
+  // ------- フィルタ機能 -------
+  // 筋肉部位や種目で絞り込みを行う
   var muscleFilter = document.getElementById('muscleFilter');
   var exerciseFilter = document.getElementById('exerciseFilter');
 
   function updateFilters(){
+    // 選択された条件に合わせて行を表示/非表示
     var mVal = muscleFilter ? muscleFilter.value : '';
     var eVal = exerciseFilter ? exerciseFilter.value : '';
     document.querySelectorAll('#workoutTable tbody .data-row').forEach(function(row){
@@ -36,7 +39,7 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   });
 
-  // Toggle new exercise form
+  // ------- エクササイズ追加フォーム表示切替 -------
   var toggleFormBtn = document.getElementById('toggleForm');
   var exerciseForm = document.getElementById('exerciseForm');
   var cancelAdd = document.getElementById('cancelAdd');
@@ -51,11 +54,12 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   }
 
-  // Add new log entry
+  // ------- 行の追加 -------
   var addEntryBtn = document.getElementById('addEntry');
   var entriesDiv = document.getElementById('entries');
 
   function attachExerciseListener(entry){
+    // 種目選択時にデフォルト値を入力する
     var select = entry.querySelector('.exercise-select');
     if(select){
       select.addEventListener('change', function(){
@@ -98,6 +102,7 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   }
 
+  // 行削除ボタンの処理
   document.addEventListener('click', function(e){
     if(e.target.classList.contains('removeEntry')){
       e.target.parentElement.remove();
@@ -105,6 +110,7 @@ document.addEventListener('DOMContentLoaded', function() {
   });
 
   // allow manual weight input
+  // ------- 手動入力用設定 -------
   var logForm = document.getElementById('logForm');
   if(logForm){
     logForm.addEventListener('submit', function(){
@@ -114,6 +120,7 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   }
 
+  // ------- モーダルでのログ登録 -------
   var logModalBtn = document.getElementById('openLogModal');
   if(logModalBtn){
     logModalBtn.addEventListener('click', function(){
@@ -140,7 +147,7 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   }
 
-  // modal handling
+  // ------- モーダルの開閉処理 -------
   var modal = document.getElementById('modal');
   var modalBody = document.getElementById('modalBody');
   if(modal){
@@ -154,7 +161,7 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   }
 
-  // calendar popup
+  // ------- カレンダーの日付クリック -------
   document.querySelectorAll('.calendar td[data-date]').forEach(function(td){
     td.addEventListener('click', function(){
       var date = this.dataset.date;
@@ -176,7 +183,7 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   });
 
-  // edit workout popup
+  // ------- ログ編集モーダル -------
   document.querySelectorAll('.edit-workout').forEach(function(el){
     el.addEventListener('click', function(e){
       e.preventDefault();
@@ -196,7 +203,7 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   });
 
-  // exercise memo popup
+  // ------- エクササイズメモ表示 -------
   document.querySelectorAll('.exercise-note').forEach(function(el){
     el.addEventListener('click', function(e){
       var memo = this.dataset.memo;
@@ -217,7 +224,7 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   });
 
-  // edit exercise popup
+  // ------- エクササイズ編集モーダル -------
   document.querySelectorAll('.edit-exercise').forEach(function(el){
     el.addEventListener('click', function(e){
       e.preventDefault();

--- a/static/style.css
+++ b/static/style.css
@@ -1,3 +1,4 @@
+/* 基本レイアウト設定 */
 body {
   font-family: Arial, sans-serif;
   max-width: 800px;
@@ -5,12 +6,14 @@ body {
   line-height: 1.6;
 }
 
+/* ナビゲーションリンク */
 nav a {
   margin: 0 8px;
   text-decoration: none;
   color: #007acc;
 }
 
+/* テーブルの基本スタイル */
 table {
   width: 100%;
   border-collapse: collapse;
@@ -42,20 +45,24 @@ button {
   border-radius: 4px;
 }
 
+/* 当月以外の日付 */
 .other-month {
   background-color: #f0f0f0;
 }
+/* カレンダー全体 */
 .calendar {
   width: 100%;
   border-collapse: collapse;
   margin-top: 16px;
 }
 
+/* カレンダーのヘッダ */
 .calendar th {
   background-color: #007acc;
   color: #fff;
 }
 
+/* カレンダーの日付セル */
 .calendar td {
   height: 80px;
   vertical-align: top;
@@ -63,11 +70,13 @@ button {
   width: 14.28%;
 }
 
+/* 今日の日付のハイライト */
 .calendar td.today {
   background-color: #fff7e6;
   border: 2px solid #ff9800;
 }
 
+/* ログが存在する日付 */
 .calendar td.has-event {
   background-color: #eaf6ff;
 }
@@ -123,6 +132,7 @@ button {
   cursor: pointer;
 }
 
+/* モーダルの背景 */
 .modal {
   position: fixed;
   left: 0;
@@ -135,6 +145,7 @@ button {
   justify-content: center;
 }
 
+/* モーダル内のコンテンツ */
 .modal-content {
   background: #fff;
   padding: 20px;
@@ -143,6 +154,7 @@ button {
   width: 90%;
 }
 
+/* 閉じるボタン */
 .close {
   float: right;
   cursor: pointer;

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- 全ページ共通のテンプレート -->
 <html lang="ja">
 <head>
   <meta charset="UTF-8">
@@ -6,6 +7,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>
+  <!-- ナビゲーションメニュー -->
   <nav>
     <a href="{{ url_for('index') }}">履歴</a> |
     <a href="{{ url_for('calendar_view') }}">カレンダー</a> |
@@ -13,12 +15,14 @@
   </nav>
   <hr>
   {% block content %}{% endblock %}
+  <!-- ポップアップ表示用のモーダル -->
   <div id="modal" class="modal" style="display:none;">
     <div class="modal-content">
       <span class="close">&times;</span>
       <div id="modalBody"></div>
     </div>
   </div>
+  <!-- JavaScript 読み込み -->
   <script src="{{ url_for('static', filename='script.js') }}"></script>
 </body>
 </html>

--- a/templates/calendar.html
+++ b/templates/calendar.html
@@ -2,6 +2,7 @@
 {% block title %}カレンダー{% endblock %}
 {% block content %}
 <h1>{{ year }}年{{ month }}月</h1>
+<!-- 月移動用リンク -->
 <div class="calendar-nav">
   <a href="{{ url_for('calendar_view', year=prev_year, month=prev_month) }}">&laquo; 前月</a> |
   <a href="{{ url_for('calendar_view', year=next_year, month=next_month) }}">翌月 &raquo;</a>
@@ -17,13 +18,16 @@
     <th>土</th>
   </tr>
   {% for week in days %}
+  <!-- 1週間分の行 -->
   <tr>
       {% for day in week %}
+      <!-- 各日のセル -->
       {% set date_str = day.strftime('%Y-%m-%d') %}
       <td class="{% if day.month != month %}other-month {% endif %}{% if day == today %}today {% endif %}{% if events.get(date_str) %}has-event{% endif %}" data-date="{{ date_str }}">
         <div class="date-number"><a href="#" class="day-link">{{ day.day }}</a></div>
         {% set day_events = events.get(date_str, []) %}
         {% if day_events %}
+        <!-- その日の種目一覧 -->
         <ul class="events">
           {% for name in day_events %}
           <li style="background-color:{% if name == '胸' %}#fddede{% elif name == '背中' %}#defdfd{% elif name == '脚' %}#e0f2e9{% elif name == '肩' %}#fdf7de{% elif name == '腕' %}#fce4ec{% elif name == '腹' %}#f0f0f0{% else %}#ffffff{% endif %};">{{ name }}</li>

--- a/templates/day_detail.html
+++ b/templates/day_detail.html
@@ -3,6 +3,7 @@
 {% block content %}
 <h1>{{ date }} のトレーニング</h1>
 {% if workouts %}
+<!-- ログがある場合 -->
 <table>
   <tr>
     <th>種目</th>
@@ -22,6 +23,7 @@
   {% endfor %}
 </table>
 {% else %}
+<!-- ログが無い場合 -->
 <p>記録がありません。</p>
 {% endif %}
 {% endblock %}

--- a/templates/edit_exercise.html
+++ b/templates/edit_exercise.html
@@ -2,6 +2,7 @@
 {% block title %}エクササイズ編集{% endblock %}
 {% block content %}
 <h1>エクササイズを編集</h1>
+<!-- エクササイズ編集フォーム -->
 <form method="post">
   <table>
     <tr>
@@ -11,6 +12,7 @@
     <tr>
       <td>部位：</td>
       <td>
+        <!-- どの部位を鍛えるか選択 -->
         <select name="muscle_group">
           <option value="胸" {% if exercise.muscle_group == '胸' %}selected{% endif %}>胸</option>
           <option value="背中" {% if exercise.muscle_group == '背中' %}selected{% endif %}>背中</option>

--- a/templates/edit_exercise_form.html
+++ b/templates/edit_exercise_form.html
@@ -1,4 +1,5 @@
 <h1>エクササイズを編集</h1>
+<!-- モーダル用エクササイズ編集フォーム -->
 <form method="post" id="editExerciseForm">
   <table>
     <tr>
@@ -8,6 +9,7 @@
     <tr>
       <td>部位：</td>
       <td>
+        <!-- 部位を選択 -->
         <select name="muscle_group">
           <option value="胸" {% if exercise.muscle_group == '胸' %}selected{% endif %}>胸</option>
           <option value="背中" {% if exercise.muscle_group == '背中' %}selected{% endif %}>背中</option>

--- a/templates/edit_workout.html
+++ b/templates/edit_workout.html
@@ -2,6 +2,7 @@
 {% block title %}ログ編集{% endblock %}
 {% block content %}
 <h1>ログを編集</h1>
+<!-- 編集フォーム -->
 <form method="post" id="editWorkoutForm">
   <table>
     <tr>
@@ -11,6 +12,7 @@
     <tr>
       <td>種目：</td>
       <td>
+        <!-- 種目を選択 -->
         <select name="exercise_id">
           {% for e in exercises %}
             <option value="{{ e.id }}" {% if e.id == workout.exercise_id %}selected{% endif %}>{{ e.name }}（{{ e.muscle_group }}）</option>

--- a/templates/edit_workout_form.html
+++ b/templates/edit_workout_form.html
@@ -1,4 +1,5 @@
 <h1>ログを編集</h1>
+<!-- モーダル内で使用する編集フォーム -->
 <form method="post" id="editWorkoutForm">
   <table>
     <tr>
@@ -8,6 +9,7 @@
     <tr>
       <td>種目：</td>
       <td>
+        <!-- 種目を選択 -->
         <select name="exercise_id">
           {% for e in exercises %}
             <option value="{{ e.id }}" {% if e.id == workout.exercise_id %}selected{% endif %}>{{ e.name }}（{{ e.muscle_group }}）</option>

--- a/templates/exercises.html
+++ b/templates/exercises.html
@@ -3,6 +3,7 @@
 {% block content %}
 <h1>エクササイズ管理</h1>
 <h2><button type="button" id="toggleForm">新しいエクササイズを追加</button></h2>
+<!-- 追加フォームは最初非表示 -->
 <div id="exerciseForm" style="display:none;">
   <form method="post">
     名前：<input type="text" name="name" required>
@@ -52,8 +53,12 @@
     <th>操作</th>
   </tr>
   {% for e in exercises %}
+  <!-- 各エクササイズの行 -->
   <tr>
-    <td><a href="#" class="exercise-note" data-memo="{{ e.memo|default('') }}" data-video="{{ e.video_url|default('') }}">{{ numbers[e.id] }}</a></td>
+    <td>
+      <!-- メモや動画URLをモーダルで表示 -->
+      <a href="#" class="exercise-note" data-memo="{{ e.memo|default('') }}" data-video="{{ e.video_url|default('') }}">{{ numbers[e.id] }}</a>
+    </td>
     <td>{{ e.name }}</td>
     <td>{{ e.muscle_group }}</td>
     <td>

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,8 +2,10 @@
 {% block title %}トレーニング履歴{% endblock %}
 {% block content %}
 <h1>トレーニング履歴</h1>
+<!-- 記録追加用モーダルを開くボタン -->
 <button type="button" id="openLogModal">記録</button>
 
+<!-- 表示フィルター -->
 <label for="muscleFilter">部位フィルター:</label>
 <select id="muscleFilter">
   <option value="">全て</option>
@@ -23,6 +25,7 @@
 </select>
 
 {% if workouts %}
+<!-- ログがある場合はテーブル表示 -->
 <table id="workoutTable">
   <thead>
     <tr>
@@ -38,6 +41,7 @@
   </thead>
   <tbody>
   {% for w in workouts %}
+  <!-- 行の色を部位ごとに変更 -->
   <tr class="data-row" data-muscle="{{ w.muscle_group }}" data-exercise="{{ w.exercise }}" style="background-color:
       {% if w.muscle_group == '胸' %}#fddede
       {% elif w.muscle_group == '背中' %}#defdfd
@@ -56,6 +60,7 @@
     <td>{{ w.weight }}</td>
     <td>{{ w.intensity }}</td>
       <td>
+        <!-- 編集ボタンはモーダルでフォームを開く -->
         <a href="#" class="button-link edit-workout" data-id="{{ w.id }}">編集</a>
         <form method="post" action="{{ url_for('delete_workout', wid=w.id) }}" style="display:inline">
           <button type="submit" onclick="return confirm('本当にこのログを削除しますか？')">削除</button>
@@ -66,6 +71,7 @@
 </tbody>
 </table>
 {% else %}
+<!-- ログが無い場合のメッセージ -->
 <p>まだログがありません。記録ボタンから追加しましょう。</p>
 {% endif %}
 

--- a/templates/log_form.html
+++ b/templates/log_form.html
@@ -1,4 +1,5 @@
 <h1>トレーニングログを記録</h1>
+<!-- モーダル内のフォーム -->
 <form method="post" id="logFormModal">
   <div class="entry">
     <table>
@@ -9,6 +10,7 @@
       <tr>
         <td>種目：</td>
         <td>
+          <!-- 種目選択 -->
           <select name="exercise_id" class="exercise-select" required>
             <option value="" selected disabled>選択せよ</option>
             {% for e in exercises %}

--- a/templates/random.html
+++ b/templates/random.html
@@ -3,12 +3,14 @@
 {% block content %}
 <h1>本日のランダムメニュー</h1>
 {% if workout %}
+<!-- ランダムに選ばれたメニュー -->
 <ol>
   {% for w in workout %}
   <li>{{ w.name }}（{{ w.muscle_group }}） — {{ w.sets }}セット × {{ w.reps }}回</li>
   {% endfor %}
 </ol>
 {% else %}
+<!-- エクササイズが無い場合の案内 -->
 <p>エクササイズが未登録です。<a href="{{ url_for('exercises') }}">まずは種目を追加</a></p>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- add explanatory Japanese comments across Flask app
- comment templates, CSS, and JavaScript for beginners

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68419718f8f08324804c906c3ba9628f